### PR TITLE
Add CRM dashboard

### DIFF
--- a/unifood_app/templates/unifood_app/crm/dashboard.html
+++ b/unifood_app/templates/unifood_app/crm/dashboard.html
@@ -1,0 +1,33 @@
+{% extends 'unifood_app/usuario/base_page.html' %}
+{% block title %}CRM Dashboard{% endblock %}
+{% block content %}
+<div class="container my-5" style="padding-top: 80px;">
+    <h2 class="container-title">CRM Dashboard</h2>
+    <div class="row text-center">
+        <div class="col-md-4 mb-3">
+            <div class="card shadow-sm">
+                <div class="card-body">
+                    <h5 class="card-title">Pedidos</h5>
+                    <p class="display-6">{{ total_pedidos }}</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4 mb-3">
+            <div class="card shadow-sm">
+                <div class="card-body">
+                    <h5 class="card-title">Produtos</h5>
+                    <p class="display-6">{{ total_produtos }}</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4 mb-3">
+            <div class="card shadow-sm">
+                <div class="card-body">
+                    <h5 class="card-title">Clientes</h5>
+                    <p class="display-6">{{ total_clientes }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/unifood_app/templates/unifood_app/usuario/base_page.html
+++ b/unifood_app/templates/unifood_app/usuario/base_page.html
@@ -117,6 +117,7 @@
     {% if eh_vendedor %}
     <a href="{% url 'cadastro' %}" title="Produtos" class="cadastro"><i class="fas fa-clipboard-list"></i></a>
     <a href="{% url 'listar_pedidos' %}" title="Pedidos" class="pedido"><i class="fas fa-box-open"></i></a>
+    <a href="{% url 'crm_dashboard' %}" title="CRM"><i class="fas fa-chart-line"></i></a>
     {% endif %}
   </nav>
 

--- a/unifood_app/tests/views/test_crm.py
+++ b/unifood_app/tests/views/test_crm.py
@@ -1,0 +1,19 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from unifood_app.models import Usuario
+
+User = get_user_model()
+
+
+class CRMDashboardViewTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='crmuser', password='testpass')
+        Usuario.objects.create(user=self.user, ra='9999999999')
+        self.client.login(username='crmuser', password='testpass')
+
+    def test_dashboard_page(self):
+        response = self.client.get(reverse('crm_dashboard'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'unifood_app/crm/dashboard.html')
+

--- a/unifood_app/urls.py
+++ b/unifood_app/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import usuario, pedidos, produto, item_pedido
+from .views import usuario, pedidos, produto, item_pedido, crm
 from .views.produto import ProdutoCreateAPIView
 
 urlpatterns = [
@@ -15,6 +15,7 @@ urlpatterns = [
     path('pedido/remover_pedido', pedidos.remover_pedido, name='remover_pedido'),
     path('produto/feed_produtos', produto.feed_produtos, name="feed"),
     path('item_pedido/listar/<int:pedido_id>/', item_pedido.listar_itens_pedido, name="listar_itens_pedido"),
+    path('crm/dashboard', crm.dashboard, name='crm_dashboard'),
     path('api/produtos/', ProdutoCreateAPIView.as_view(), name='api-produto-create'),
 ]
 

--- a/unifood_app/views/crm.py
+++ b/unifood_app/views/crm.py
@@ -1,0 +1,22 @@
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import render
+from unifood_app.models import Pedido, Produto
+
+
+@login_required
+def dashboard(request):
+    total_pedidos = Pedido.objects.filter(vendedor=request.user).count()
+    total_produtos = Produto.objects.filter(vendedor=request.user).count()
+    total_clientes = (
+        Pedido.objects.filter(vendedor=request.user)
+        .values('cliente')
+        .distinct()
+        .count()
+    )
+
+    context = {
+        'total_pedidos': total_pedidos,
+        'total_produtos': total_produtos,
+        'total_clientes': total_clientes,
+    }
+    return render(request, 'unifood_app/crm/dashboard.html', context)


### PR DESCRIPTION
## Summary
- add CRM dashboard view and URL
- create CRM dashboard template showing order, product and client counts
- expose CRM link in sidebar
- test CRM dashboard view

## Testing
- `pipenv run cov` *(fails: pipenv not installed)*
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ed89ab30c833291ba1204515f70f2